### PR TITLE
Fix Multiple Clusters

### DIFF
--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn compute Service
 
 type: application
 
-version: v1.2.0-rc1
-appVersion: v1.2.0-rc1
+version: v1.2.0-rc2
+appVersion: v1.2.0-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
Good catch by staging!  We want to filter servers and security groups by cluster, not outright reject them if the cluster is a mismatch due to the API list interface returning all resources related to the organization and not scoped to a specific cluster.  We should perhaps allow the list APIs to choose a tag selector and push this down in the next release.