### PR TITLE
Use Region Filtering API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spjmurray/go-util v0.1.3
-	github.com/unikorn-cloud/core v1.2.0
+	github.com/unikorn-cloud/core v1.2.1-0.20250603100447-a7ef1ff8d333
 	github.com/unikorn-cloud/identity v1.2.0
-	github.com/unikorn-cloud/region v1.2.0
+	github.com/unikorn-cloud/region v1.2.1-0.20250603103003-bc4b36ca3417
 	go.opentelemetry.io/otel/sdk v1.35.0
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1

--- a/go.sum
+++ b/go.sum
@@ -139,12 +139,12 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v1.2.0 h1:6bwBUzGZaYANwkv1K8TX/0rGCc+EgaV6mlB64q67AXg=
-github.com/unikorn-cloud/core v1.2.0/go.mod h1:w+knncdBlLfVg82Ky3BejohUqiXrCUPFnAup1yZYbyM=
+github.com/unikorn-cloud/core v1.2.1-0.20250603100447-a7ef1ff8d333 h1:WDQGl8KtQeqEnnBYawel/MPlOnftfnK1ox/21Us8HXM=
+github.com/unikorn-cloud/core v1.2.1-0.20250603100447-a7ef1ff8d333/go.mod h1:w+knncdBlLfVg82Ky3BejohUqiXrCUPFnAup1yZYbyM=
 github.com/unikorn-cloud/identity v1.2.0 h1:Hbokk7UqRWEF1mIhggg35tUApopcM8y5FQ1wPoUcBv0=
 github.com/unikorn-cloud/identity v1.2.0/go.mod h1:iylaGCOKPMLFkmySLDqswkJlPGp+QQQABDphMIVaaFQ=
-github.com/unikorn-cloud/region v1.2.0 h1:3fzEGBClQo3dWWduqatreZsHA5t8KwFKFt5gSinjfLI=
-github.com/unikorn-cloud/region v1.2.0/go.mod h1:2RrDRVQ9c2GZ3b2p6qqaAC8kCGXButxaYfs4msriSAk=
+github.com/unikorn-cloud/region v1.2.1-0.20250603103003-bc4b36ca3417 h1:P0yLdch9mGmL6tuxyWvWo7DbF6w2GM6LviOzH78RRZo=
+github.com/unikorn-cloud/region v1.2.1-0.20250603103003-bc4b36ca3417/go.mod h1:OAJBDKbqS1WJXvYzpimYD871Ybwa8+oEnTC6U527CYM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Trialling strategies for resource filtering where it's relevant.  Where possible APIs should provide filtering of resources based on common metadata e.g. projects, tags etc.  THis means you write once, use anywhere, rather than having to replicate the functionality in every client.  This uses tag filters to get cluster specific servers and security groups.